### PR TITLE
Add setup guide and fix extension installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Guidelines
+
+To work with this project, set up the environment and dependencies as follows.
+
+## Environment Setup
+
+1. **Install `just`** (command runner used for setup):
+   ```bash
+   apt-get update && apt-get install -y just
+   ```
+
+2. **Install project dependencies** (includes `pysqlite3-binary` for extension support):
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## Download Required Assets
+
+Use the provided justfile recipes to obtain the embedding model and SQLite extensions:
+
+```bash
+just play
+```
+This will
+- download the `all-MiniLM-L6-v2` embedding model,
+- install the `sqlite-lembed` extension, and
+- install the `sqlite-vec` extension
+into `src/hypergraph_db/sql/`.
+
+## Running Tests
+
+Execute the test suite with the project sources on the Python path:
+
+```bash
+PYTHONPATH=src pytest
+```
+
+## Notes
+- The database utilities rely on `pysqlite3` so that `enable_load_extension` is available.
+- All setup steps must be run from the repository root.

--- a/justfile
+++ b/justfile
@@ -11,10 +11,10 @@ install-sqlite-lembed:
     @echo "Creating ./src/hypergraph_db/sql directory if it doesn't exist..."
     mkdir -p src/hypergraph_db/sql
     @echo "Downloading and installing sqlite-lembed extension..."
-    curl -L -o install.sh https://github.com/asg017/sqlite-lembed/releases/download/v0.0.1-alpha.8/install.sh
-    chmod +x install.sh
-    ./install.sh loadable --prefix=src/hypergraph_db/sql
-    rm install.sh
+    curl -L -o src/hypergraph_db/sql/install.sh https://github.com/asg017/sqlite-lembed/releases/download/v0.0.1-alpha.8/install.sh
+    chmod +x src/hypergraph_db/sql/install.sh
+    (cd src/hypergraph_db/sql && bash install.sh loadable)
+    rm src/hypergraph_db/sql/install.sh
     @echo "sqlite-lembed has been successfully installed in ./src/hypergraph_db/sql."
 
 # Download and install sqlite-vec extension
@@ -22,10 +22,10 @@ install-sqlite-vec:
     @echo "Creating ./src/hypergraph_db/sql directory if it doesn't exist..."
     mkdir -p src/hypergraph_db/sql
     @echo "Downloading and installing sqlite-vec extension..."
-    curl -L -o install.sh https://github.com/asg017/sqlite-vec/releases/download/v0.1.3/install.sh
-    chmod +x install.sh
-    ./install.sh loadable --prefix=src/hypergraph_db/sql
-    rm install.sh
+    curl -L -o src/hypergraph_db/sql/install.sh https://github.com/asg017/sqlite-vec/releases/download/v0.1.3/install.sh
+    chmod +x src/hypergraph_db/sql/install.sh
+    (cd src/hypergraph_db/sql && bash install.sh loadable)
+    rm src/hypergraph_db/sql/install.sh
     @echo "sqlite-vec has been successfully installed in ./src/hypergraph_db/sql."
 
 # Run all commands in sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "black>=23.1.0",
     "sqlparse>=0.4.4",
     "mkdocs-techdocs-core>=1.4.2",
+    "pysqlite3-binary>=0.5.4",
 ]
 
 [project.optional-dependencies]

--- a/src/hypergraph_db/database.py
+++ b/src/hypergraph_db/database.py
@@ -1,4 +1,7 @@
-import sqlite3
+try:
+    import pysqlite3 as sqlite3
+except ModuleNotFoundError:  # pragma: no cover - fallback when extension not available
+    import sqlite3
 from typing import List, Optional, Any, Dict
 from pathlib import Path
 

--- a/src/hypergraph_db/utils.py
+++ b/src/hypergraph_db/utils.py
@@ -1,4 +1,7 @@
-import sqlite3
+try:
+    import pysqlite3 as sqlite3
+except ModuleNotFoundError:  # pragma: no cover - fallback when extension not available
+    import sqlite3
 from pathlib import Path
 
 


### PR DESCRIPTION
## Summary
- add AGENTS.md with setup steps for model and SQLite extensions
- fix justfile installation scripts to run in target directory
- allow database utilities to use pysqlite3 for extension support
- document dependency installation with pysqlite3-binary
- include `pysqlite3-binary` as a project dependency

## Testing
- `just play`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa9b8ca01c8331a96b92b2147046fb