### PR TITLE
Fix dynamic hyperedge search placeholder bug

### DIFF
--- a/src/hypergraph_db/database.py
+++ b/src/hypergraph_db/database.py
@@ -102,9 +102,9 @@ class HypergraphDB:
 
     def search_hyperedges(self, node_ids: List[str]):
         """Search for hyperedges that connect specific nodes."""
-        sql = SQLScripts.get_script("search_hyperedges.sql")
+        sql_template = SQLScripts.get_script("search_hyperedges.sql")
         placeholders = ",".join(["?"] * len(node_ids))
-        query = sql.replace("?", placeholders, 1)
+        query = sql_template.format(placeholders=placeholders)
         params = node_ids + [len(node_ids)]
         cursor = self.connection.execute(query, params)
         return cursor.fetchall()

--- a/src/hypergraph_db/sql/search_hyperedges.sql
+++ b/src/hypergraph_db/sql/search_hyperedges.sql
@@ -1,5 +1,5 @@
 SELECT hyperedge_id
 FROM node_hyperedge_map
-WHERE node_id IN (?, ?)
+WHERE node_id IN ({placeholders})
 GROUP BY hyperedge_id
 HAVING COUNT(DISTINCT node_id) = ?;

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -62,3 +62,22 @@ def test_traverse_hypergraph(db):
 
     traversal = db.traverse_hypergraph("node1")
     assert len(traversal) > 0
+
+
+def test_search_hyperedges_multiple_nodes(db):
+    node_ids = ["node1", "node2", "node3"]
+    nodes = [Node(body=f"{{\"id\": \"{nid}\"}}") for nid in node_ids]
+    for node in nodes:
+        db.insert_node(node)
+
+    hyperedge = Hyperedge(
+        edge_id="edge_multi",
+        properties="{}",
+        nodes=str(node_ids).replace("'", '"'),
+    )
+    db.insert_hyperedge(hyperedge)
+    for order, nid in enumerate(node_ids, 1):
+        db.insert_node_hyperedge_map("edge_multi", nid, order)
+
+    results = db.search_hyperedges(node_ids)
+    assert any(row["hyperedge_id"] == "edge_multi" for row in results)


### PR DESCRIPTION
## Summary
- Fix dynamic placeholder substitution in `search_hyperedges` to handle arbitrary node counts
- Update SQL template for hyperedge search to accept formatted placeholders
- Add test covering hyperedge searches with more than two nodes

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa9ead524c8331aea6e2cc422a3421