### PR TITLE
Fix property search in HypergraphDB

### DIFF
--- a/src/hypergraph_db/database.py
+++ b/src/hypergraph_db/database.py
@@ -66,8 +66,8 @@ class HypergraphDB:
     def search_nodes_by_property(self, key: str, value: Any) -> List[Node]:
         """Search for nodes based on properties in their JSON body."""
         sql = SQLScripts.get_script("search_nodes_by_properties.sql")
-        sql = sql.replace("$.key", f"$['{key}']")
-        cursor = self.connection.execute(sql, (value,))
+        json_path = f"$.{key}"
+        cursor = self.connection.execute(sql, (json_path, value))
         rows = cursor.fetchall()
         return [Node(body=row["body"], node_id=row["id"]) for row in rows]
 

--- a/src/hypergraph_db/sql/search_nodes_by_properties.sql
+++ b/src/hypergraph_db/sql/search_nodes_by_properties.sql
@@ -1,0 +1,4 @@
+SELECT id, body
+FROM nodes
+WHERE json_extract(body, ?) = ?;
+

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -15,6 +15,17 @@ def test_insert_node(db):
     assert inserted_node.id == "node1"
 
 
+def test_search_nodes_by_property(db):
+    node1 = Node(body='{"id": "node1", "name": "Alpha"}')
+    node2 = Node(body='{"id": "node2", "name": "Beta"}')
+    db.insert_node(node1)
+    db.insert_node(node2)
+
+    results = db.search_nodes_by_property("name", "Alpha")
+    assert len(results) == 1
+    assert results[0].id == "node1"
+
+
 def test_insert_hyperedge(db):
     hyperedge = Hyperedge(
         edge_id="edge1", properties='{"weight":1}', nodes='["node1", "node2"]'


### PR DESCRIPTION
## Summary
- implement SQL query for searching nodes by property and pass JSON path as parameter
- add tests for property lookup

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa9ead524c8331aea6e2cc422a3421